### PR TITLE
fix load call

### DIFF
--- a/www/app_groups_user_defaults.js
+++ b/www/app_groups_user_defaults.js
@@ -5,7 +5,7 @@ AppGroupsUserDefaults.prototype.save = function(options, success, fail) {
 };
 
 AppGroupsUserDefaults.prototype.load = function(options, success, fail) {
-  cordova.exec(success(result), fail(), "AppGroupsUserDefaults", "load", [options]);
+  cordova.exec(success, fail, "AppGroupsUserDefaults", "load", [options]);
 };
 
 var appGroupsUserDefaults = new AppGroupsUserDefaults();


### PR DESCRIPTION
Load call wasn't working properly, because the callbacks were being executed instead of passed into the `cordova.exec`.
